### PR TITLE
[SQL] Order results by count, boosting exact matches to the top

### DIFF
--- a/sql/fetch_tags_a.sql
+++ b/sql/fetch_tags_a.sql
@@ -5,7 +5,7 @@
         tags.post_count,
         tags.category,
         NULL AS antecedent_name,
-        length(tags.name) AS name_length
+        regexp_replace(tags.name, '_\(.*\)$', '') AS stripped_name
     FROM tags
     WHERE tags.name LIKE $1 ESCAPE E'\\'
       AND tags.post_count > 0
@@ -20,7 +20,7 @@ UNION ALL
         post_count,
         category,
         antecedent_name,
-        length(antecedent_name) AS name_length
+        regexp_replace(tags.name, '_\(.*\)$', '') AS stripped_name
     FROM (
         SELECT DISTINCT ON (name)
             id,
@@ -49,5 +49,7 @@ UNION ALL
     ORDER BY post_count DESC
     LIMIT 10
 )
-ORDER BY name_length, post_count DESC
+ORDER BY
+    CASE WHEN regexp_replace(tags.name, '_\(.*\)$', '') = $2 THEN 0 ELSE 1 END,
+    post_count DESC
 LIMIT 10

--- a/sql/fetch_tags_a.sql
+++ b/sql/fetch_tags_a.sql
@@ -5,7 +5,7 @@
         tags.post_count,
         tags.category,
         NULL AS antecedent_name,
-        regexp_replace(tags.name, '_\(.*\)$', '') AS stripped_name
+        (CASE WHEN regexp_replace(tags.name, '_\(.*\)$', '') = $2 THEN 0 ELSE 1 END) AS stripped_name
     FROM tags
     WHERE tags.name LIKE $1 ESCAPE E'\\'
       AND tags.post_count > 0
@@ -20,7 +20,7 @@ UNION ALL
         post_count,
         category,
         antecedent_name,
-        regexp_replace(tags.name, '_\(.*\)$', '') AS stripped_name
+        (CASE WHEN regexp_replace(antecedent_name, '_\(.*\)$', '') = $2 THEN 0 ELSE 1 END) AS stripped_name
     FROM (
         SELECT DISTINCT ON (name)
             id,
@@ -41,7 +41,7 @@ UNION ALL
               AND tag_aliases.status IN ('active', 'processing', 'queued')
               AND tag_aliases.post_count > 0
               AND tags.name NOT LIKE $1 ESCAPE E'\\'
-            ORDER BY tags.post_count, length(tag_aliases.antecedent_name) DESC
+            ORDER BY tags.post_count DESC
             LIMIT 50
         ) pre_limited
         ORDER BY name, post_count DESC
@@ -49,7 +49,5 @@ UNION ALL
     ORDER BY post_count DESC
     LIMIT 10
 )
-ORDER BY
-    CASE WHEN regexp_replace(tags.name, '_\(.*\)$', '') = $2 THEN 0 ELSE 1 END,
-    post_count DESC
-LIMIT 10
+ORDER BY stripped_name, post_count DESC
+LIMIT 10;

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ async fn main() -> std::io::Result<()> {
         .create_pool(Some(Runtime::Tokio1), NoTls)
         .expect("Failed to create PostgreSQL connection pool");
     let cache = CacheBuilder::new(15_000)
-        .time_to_live(Duration::from_secs(60))
+        .time_to_live(Duration::from_secs(6 * 60 * 60))
         .build();
 
     HttpServer::new(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,14 +64,13 @@ mod db {
         client: &Client,
         tag_prefix: &String,
     ) -> Result<Vec<Tag>, tokio_postgres::Error> {
-        let tag_prefix_str = escape_like(tag_prefix);
-        let escape_prefix = format!("{tag_prefix_str}%");
+        let like_pattern = format!("{}%", escape_like(tag_prefix));
 
         let stmt = client
             .prepare_cached(include_str!("../sql/fetch_tags_a.sql"))
             .await?;
         let rows = client
-            .query(&stmt, &[&escape_prefix, &tag_prefix_str])
+            .query(&stmt, &[&like_pattern, &tag_prefix])
             .await?
             .iter()
             .map(|row| Tag::from_row_ref(row).unwrap())

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,12 +64,14 @@ mod db {
         client: &Client,
         tag_prefix: &String,
     ) -> Result<Vec<Tag>, tokio_postgres::Error> {
-        let escape_prefix = escape_like(&(tag_prefix.to_owned() + "*"));
+        let tag_prefix_str = escape_like(tag_prefix);
+        let escape_prefix = format!("{tag_prefix_str}%");
+
         let stmt = client
             .prepare_cached(include_str!("../sql/fetch_tags_a.sql"))
             .await?;
         let rows = client
-            .query(&stmt, &[&escape_prefix])
+            .query(&stmt, &[&escape_prefix, &tag_prefix_str])
             .await?
             .iter()
             .map(|row| Tag::from_row_ref(row).unwrap())
@@ -207,7 +209,7 @@ async fn main() -> std::io::Result<()> {
         .create_pool(Some(Runtime::Tokio1), NoTls)
         .expect("Failed to create PostgreSQL connection pool");
     let cache = CacheBuilder::new(15_000)
-        .time_to_live(Duration::from_secs(6 * 60 * 60))
+        .time_to_live(Duration::from_secs(60))
         .build();
 
     HttpServer::new(move || {


### PR DESCRIPTION
This includes matches followed by a `_(.*)` suffix.