### PR TITLE
test: cover autocomplete input handling

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -21,3 +21,6 @@ jobs:
 
       - name: Clippy
         run: cargo clippy -- -D warnings
+
+      - name: Tests
+        run: cargo test

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,11 +53,25 @@ mod db {
     use crate::models::Tag;
 
     fn escape_like(stuff: &str) -> String {
-        stuff
-            .replace('%', "\\%")
-            .replace('_', "\\_")
-            .replace('*', "%")
-            .replace("\\*", "*")
+        let mut escaped = String::new();
+        let mut chars = stuff.chars().peekable();
+
+        while let Some(ch) = chars.next() {
+            if ch == '\\' && chars.peek() == Some(&'*') {
+                chars.next();
+                escaped.push('*');
+                continue;
+            }
+
+            match ch {
+                '%' => escaped.push_str("\\%"),
+                '_' => escaped.push_str("\\_"),
+                '*' => escaped.push('%'),
+                other => escaped.push(other),
+            }
+        }
+
+        escaped
     }
 
     pub async fn get_tags(
@@ -88,6 +102,29 @@ mod db {
             .map(|row| Tag::from_row_ref(row).unwrap())
             .collect::<Vec<Tag>>();
         Ok(rows)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::escape_like;
+
+        #[test]
+        fn escape_like_escapes_sql_wildcards() {
+            assert_eq!(escape_like("100%"), "100\\%");
+            assert_eq!(escape_like("blue_eyes"), "blue\\_eyes");
+        }
+
+        #[test]
+        fn escape_like_converts_unescaped_stars_to_like_wildcards() {
+            assert_eq!(escape_like("cat*"), "cat%");
+            assert_eq!(escape_like("foo%_bar*baz"), "foo\\%\\_bar%baz");
+        }
+
+        #[test]
+        fn escape_like_preserves_escaped_stars_as_literals() {
+            assert_eq!(escape_like(r"foo\*bar"), "foo*bar");
+            assert_eq!(escape_like(r"\*literal*"), "*literal%");
+        }
     }
 }
 
@@ -144,6 +181,45 @@ fn validate_transform_tag(tag: &str) -> Result<String, AutocompleteError> {
         return Err(AutocompleteError::BadRequest);
     }
     Ok(tag_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_transform_tag, AutocompleteError};
+
+    #[test]
+    fn validate_transform_tag_normalizes_lowercases_and_strips_disallowed_chars() {
+        assert_eq!(
+            validate_transform_tag("  CaFe\u{301} % * \0  ").unwrap(),
+            "café"
+        );
+    }
+
+    #[test]
+    fn validate_transform_tag_counts_unicode_scalars_for_boundaries() {
+        assert_eq!(validate_transform_tag("猫犬鳥").unwrap(), "猫犬鳥");
+        assert!(matches!(
+            validate_transform_tag("猫犬"),
+            Err(AutocompleteError::BadRequest)
+        ));
+        assert!(matches!(
+            validate_transform_tag(&"a".repeat(101)),
+            Err(AutocompleteError::BadRequest)
+        ));
+        assert_eq!(validate_transform_tag(&"a".repeat(100)).unwrap().len(), 100);
+    }
+
+    #[test]
+    fn validate_transform_tag_rejects_inputs_that_clean_to_invalid_lengths() {
+        assert!(matches!(
+            validate_transform_tag("a b"),
+            Err(AutocompleteError::BadRequest)
+        ));
+        assert!(matches!(
+            validate_transform_tag("***%%%\0"),
+            Err(AutocompleteError::BadRequest)
+        ));
+    }
 }
 
 #[derive(Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,25 +53,11 @@ mod db {
     use crate::models::Tag;
 
     fn escape_like(stuff: &str) -> String {
-        let mut escaped = String::new();
-        let mut chars = stuff.chars().peekable();
-
-        while let Some(ch) = chars.next() {
-            if ch == '\\' && chars.peek() == Some(&'*') {
-                chars.next();
-                escaped.push('*');
-                continue;
-            }
-
-            match ch {
-                '%' => escaped.push_str("\\%"),
-                '_' => escaped.push_str("\\_"),
-                '*' => escaped.push('%'),
-                other => escaped.push(other),
-            }
-        }
-
-        escaped
+        stuff
+            .replace('%', "\\%")
+            .replace('_', "\\_")
+            .replace('*', "%")
+            .replace("\\*", "*")
     }
 
     pub async fn get_tags(
@@ -118,12 +104,6 @@ mod db {
         fn escape_like_converts_unescaped_stars_to_like_wildcards() {
             assert_eq!(escape_like("cat*"), "cat%");
             assert_eq!(escape_like("foo%_bar*baz"), "foo\\%\\_bar%baz");
-        }
-
-        #[test]
-        fn escape_like_preserves_escaped_stars_as_literals() {
-            assert_eq!(escape_like(r"foo\*bar"), "foo*bar");
-            assert_eq!(escape_like(r"\*literal*"), "*literal%");
         }
     }
 }


### PR DESCRIPTION
## Summary

Addresses #7 with a focused first coverage slice for the two pure input-handling helpers called out in the issue.

Changes:

- Adds unit coverage for `db::escape_like`, including `%`, `_`, bare `*`, and mixed inputs
- Adds unit coverage for `validate_transform_tag`, including Unicode normalization, CJK length boundaries, whitespace stripping, null bytes, and wildcard removal
- Adds `cargo test` to the shared checks workflow so tests run before Docker/release checks

I intentionally left the PostgreSQL two-stage query fallback for a later integration-test slice because that needs database fixtures and should stay separate from the pure helper coverage.

I also did not change escaped-star handling in `escape_like`; the related bug report was closed as invalid because request normalization strips wildcard characters before query building.

## Validation

Using Homebrew Rust 1.96.0:

- `cargo fmt --check`
- `cargo test` -> 5 tests passed
- `cargo clippy -- -D warnings`
- `git diff --check`

Submitted by Bean Labs as a public free-service contribution; acceptance is still pending maintainer review.
